### PR TITLE
Display area hide till used

### DIFF
--- a/src/js/customSelectionAdapter.js
+++ b/src/js/customSelectionAdapter.js
@@ -34,7 +34,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
 
       this.$selectionTagsContainer.html(this.$selectionTags);
 
-      this.$selectionTags.hide();
+      this.$selectionTagsContainer.addClass('select2-selection--empty');
 
       if (this.options.get('selectionContainer')) {
         this.$selectionTagsContainer.appendTo(this.options.get('selectionContainer'));
@@ -87,7 +87,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
     };
 
     CustomSelection.prototype.clear = function () {
-      this.$selectionTags.hide();
+      this.$selectionTagsContainer.addClass('select2-selection--empty');
       // we need this line to remove the existing .select2-selection__clear button
       this.$selection.find('.select2-selection__rendered').empty();
       this.$selectionTags.find('.select2-selection__rendered').empty();
@@ -118,6 +118,8 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
       if (data.length === 0) {
         return;
       }
+      
+      this.$selectionTagsContainer.removeClass('select2-selection--empty');
 
       this.$selectionTags.show();
 

--- a/src/js/customSelectionAdapter.js
+++ b/src/js/customSelectionAdapter.js
@@ -34,7 +34,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
 
       this.$selectionTagsContainer.html(this.$selectionTags);
 
-      this.$selectionTagsContainer.addClass('select2-selection--empty');
+      this.$selectionTagsContainer.addClass('select2-container--empty');
 
       if (this.options.get('selectionContainer')) {
         this.$selectionTagsContainer.appendTo(this.options.get('selectionContainer'));
@@ -87,7 +87,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
     };
 
     CustomSelection.prototype.clear = function () {
-      this.$selectionTagsContainer.addClass('select2-selection--empty');
+      this.$selectionTagsContainer.addClass('select2-container--empty');
       // we need this line to remove the existing .select2-selection__clear button
       this.$selection.find('.select2-selection__rendered').empty();
       this.$selectionTags.find('.select2-selection__rendered').empty();
@@ -119,7 +119,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
         return;
       }
       
-      this.$selectionTagsContainer.removeClass('select2-selection--empty');
+      this.$selectionTagsContainer.removeClass('select2-container--empty');
 
       var $selections = [];
 

--- a/src/js/customSelectionAdapter.js
+++ b/src/js/customSelectionAdapter.js
@@ -34,6 +34,8 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
 
       this.$selectionTagsContainer.html(this.$selectionTags);
 
+      this.$selectionTags.hide();
+
       if (this.options.get('selectionContainer')) {
         this.$selectionTagsContainer.appendTo(this.options.get('selectionContainer'));
       } else {
@@ -85,6 +87,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
     };
 
     CustomSelection.prototype.clear = function () {
+      this.$selectionTags.hide();
       // we need this line to remove the existing .select2-selection__clear button
       this.$selection.find('.select2-selection__rendered').empty();
       this.$selectionTags.find('.select2-selection__rendered').empty();
@@ -115,6 +118,8 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
       if (data.length === 0) {
         return;
       }
+
+      this.$selectionTags.show();
 
       var $selections = [];
 

--- a/src/js/customSelectionAdapter.js
+++ b/src/js/customSelectionAdapter.js
@@ -121,8 +121,6 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
       
       this.$selectionTagsContainer.removeClass('select2-selection--empty');
 
-      this.$selectionTags.show();
-
       var $selections = [];
 
       for (var d = 0; d < data.length; d++) {


### PR DESCRIPTION
Set the display area below the selection box to not take up vertical space with an empty div until items are selected.

I noticed this was an issue when the UI design expects the select list to be only the size of selected data, and none if nothing is selected. For instance currently I have a lot of select fields stacked vertically, and the forced empty space is an issue