### PR TITLE
Adapter compatibility with the latest Select2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "jquery": "^3.5.0",
-    "select2": "^4.0.7-rc.0"
+    "select2": "^4.1.0-rc.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",

--- a/src/js/customSelectionAdapter.js
+++ b/src/js/customSelectionAdapter.js
@@ -139,7 +139,7 @@ $.fn.select2.amd.define('select2/selection/customSelectionAdapter',
 
       var $rendered = this.$selectionTags.find('.select2-selection__rendered');
 
-      Utils.appendMany($rendered, $selections);
+      $rendered.append($selections);
 
       // Re-append placeholder
       if (this.placeholder && this.placeholder.text) {


### PR DESCRIPTION
Hello 👋🏻 

To use this adapter with the [latest](https://www.npmjs.com/package/select2) Select2 release (4.1.0-rc.0), I had to replace the usage of _Utils.AppendMany_, as was done in the upstream pull request: https://github.com/select2/select2/pull/5525.

Working demo: [JSFiddle](https://jsfiddle.net/p5c6xdgo/10/)